### PR TITLE
✨ Report filename and error type for PHP errors

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -258,6 +258,50 @@ class Event
     }
 
     /**
+     * Get the PHP Error constant as string for logging purposes
+     *
+     * @param int     $type PHP E_$x error constant
+     * @return string       E_$x error constant as string
+     */
+    protected function errorTypeToString($type)
+    {
+        switch ($type) {
+            case E_ERROR:
+                return 'E_ERROR';
+            case E_WARNING:
+                return 'E_WARNING';
+            case E_PARSE:
+                return 'E_PARSE';
+            case E_NOTICE:
+                return 'E_NOTICE';
+            case E_CORE_ERROR:
+                return 'E_CORE_ERROR';
+            case E_CORE_WARNING:
+                return 'E_CORE_WARNING';
+            case E_COMPILE_ERROR:
+                return 'E_COMPILE_ERROR';
+            case E_COMPILE_WARNING:
+                return 'E_COMPILE_WARNING';
+            case E_USER_ERROR:
+                return 'E_USER_ERROR';
+            case E_USER_WARNING:
+                return 'E_USER_WARNING';
+            case E_USER_NOTICE:
+                return 'E_USER_NOTICE';
+            case E_STRICT:
+                return 'E_STRICT';
+            case E_RECOVERABLE_ERROR:
+                return 'E_RECOVERABLE_ERROR';
+            case E_DEPRECATED:
+                return 'E_DEPRECATED';
+            case E_USER_DEPRECATED:
+                return 'E_USER_DEPRECATED';
+            default:
+                return 'E_UNKNOWN_ERROR_TYPE';
+        }
+    }
+
+    /**
      * Load an event from JSON encoded data
      *
      * @param string $json
@@ -279,6 +323,42 @@ class Event
         $ev = new Event();
         $ev->addException($e);
         return $ev;
+    }
+
+    /**
+     * @param array $error
+     *
+     * @return Event
+     */
+    public static function fromError($error)
+    {
+
+        $ev = new Event();
+        $ev->setError($error);
+        return $ev;
+    }
+
+    protected function setError($error)
+    {
+        $this->data['exception'] = [
+            'values' => [
+                [
+                    'type' => $this->errorTypeToString($error['type']),
+                    'value' => $error['message'],
+                    'stacktrace' => [
+                        'frames' => [
+                            [
+                                'filename' => $error['file'],
+                                'function' => '',
+                                'lineno' => $error['line'],
+                                'vars' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->setLogLevel($this->translateSeverity($error['type']));
     }
 
 }

--- a/action/errors.php
+++ b/action/errors.php
@@ -8,6 +8,8 @@
 
 // must be run within Dokuwiki
 
+use dokuwiki\plugin\sentry\Event;
+
 if (!defined('DOKU_INC')) {
     die();
 }
@@ -75,8 +77,10 @@ class action_plugin_sentry_errors extends DokuWiki_Action_Plugin
             return;
         }
 
-        $e = new \ErrorException($error['message'], $error['type'], $error['type'], $error['file'], $error['line']);
-        $this->exceptionHandler($e);
+        /** @var helper_plugin_sentry $helper */
+        $helper = plugin_load('helper', 'sentry');
+        $event = Event::fromError($error);
+        $helper->logEvent($event);
     }
 
     /**


### PR DESCRIPTION
Using the standard exception handling resulted in suboptimal events recorded in sentry. The approach implemented here has two advantages:

1. shows what kind of error was thrown (previously it would always be `ErrorException`)
1. shows in what file and line the error was thrown (previously it was always the `fatalHandler` method, becuase the exception originated there)

However, the large disadvantage is that we now have an ugly `errorTypeToString($type)` method 😕