### PR TITLE
extract public info from exceptions

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -143,6 +143,7 @@ class Event
     {
         $props = get_object_vars($e);
         if (!is_array($props)) return;
+        if (isset($props['xdebug_message'])) unset($props['xdebug_message']); // nothing interesting in there
         if (!isset($this->data['extra'])) $this->data['extra'] = [];
         $this->data['extra'] = array_merge($this->data['extra'], $props);
     }

--- a/Event.php
+++ b/Event.php
@@ -129,6 +129,22 @@ class Event
             'value' => $e->getMessage(),
             'stacktrace' => ['frames' => self::backTraceFrames($e->getTrace())],
         ];
+
+        // extract extras
+        $this->extractExceptionExtras($e);
+    }
+
+    /**
+     * Extracts all public properties of an exception into the extra array
+     *
+     * @param \Throwable $e
+     */
+    protected function extractExceptionExtras(\Throwable $e)
+    {
+        $props = get_object_vars($e);
+        if (!is_array($props)) return;
+        if (!isset($this->data['extra'])) $this->data['extra'] = [];
+        $this->data['extra'] = array_merge($this->data['extra'], $props);
     }
 
     /**


### PR DESCRIPTION
This makes it very simple for developers to log additional data. Simply store it in a public property on your exception and it will be logged to sentry.