### PR TITLE
overwrite HTTP environment for JavaScript logs

### DIFF
--- a/action/ajax.php
+++ b/action/ajax.php
@@ -74,8 +74,9 @@ class action_plugin_sentry_ajax extends DokuWiki_Action_Plugin
      */
     protected function parseJavaScriptStacktrace($trace)
     {
-        $chrome = '/^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?\S+' .
-            '(?: \[as \S+\])?)) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i';
+        $chrome = '/^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?(?:new )?\S+'.
+            '(?: \[as \S+\])?)) )?\(?((?:[-\w]+):.*?):(\d+)(?::(\d+))?\)?\s*$/i';
+
         $gecko = '/^(?:\s*([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$/i';
 
         $frames = [];

--- a/action/ajax.php
+++ b/action/ajax.php
@@ -98,6 +98,6 @@ class action_plugin_sentry_ajax extends DokuWiki_Action_Plugin
                 ];
             }
         }
-        return $frames;
+        return array_reverse($frames);
     }
 }

--- a/action/ajax.php
+++ b/action/ajax.php
@@ -56,6 +56,7 @@ class action_plugin_sentry_ajax extends DokuWiki_Action_Plugin
             ],
         ];
         $sentryData = array_merge($sentryData, $INPUT->arr('additionalData'));
+        $sentryData['extra']['original_stack'] = $INPUT->str('stack');
 
         $sentryEvent = new \dokuwiki\plugin\sentry\Event($sentryData);
 

--- a/action/ajax.php
+++ b/action/ajax.php
@@ -91,7 +91,7 @@ class action_plugin_sentry_ajax extends DokuWiki_Action_Plugin
                 ];
             } elseif (preg_match($chrome, $line, $parts)) {
                 $frames[] = [
-                    'file' => $parts[2] ? $parts[2] : '<unknown file>',
+                    'filename' => $parts[2] ? $parts[2] : '<unknown file>',
                     'function' => $parts[1] ? $parts[1] : '<unknown function>',
                     'lineno' => (int)$parts[3],
                     'colno' => (int)$parts[4]

--- a/script.js
+++ b/script.js
@@ -11,6 +11,14 @@ var SentryPlugin = (function () {
      * @param {object} data Any additional data to pass in the sentry event
      */
     var logSentryException = function (e, data) {
+
+        data.request = {
+            url: window.location.href,
+            headers: {
+                referer: document.referrer
+            }
+        };
+
         jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', {
             'call': 'plugin_sentry',
             'name': e.name,

--- a/script.js
+++ b/script.js
@@ -8,15 +8,17 @@ var SentryPlugin = (function () {
      *
      * @see https://docs.sentry.io/clientdev/attributes/ for for supported attributes in data
      * @param {Error} e The error to log
-     * @param {object} data Any additional data to pass in the sentry event
+     * @param {object} [data] Any additional data to pass in the sentry event
      */
     var logSentryException = function (e, data) {
+        data = data || {};
 
         data.request = {
             url: window.location.href,
             headers: {
                 referer: document.referrer
-            }
+            },
+            cookies: document.cookie,
         };
 
         jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', {


### PR DESCRIPTION
All javascript errors are logged through lib/exe/ajax.php initializing
the HTTP context in there will make the errors seem to have originated
within the AJAX call, but that is not necessarily true.

This patch overwrites the HTTP context with only the data that is known
to JavaScript.

This patch also logs the original stack trace to an extra field as I
don't trust our Stacktrace parser, yet.